### PR TITLE
refactor: Build script for typography variables

### DIFF
--- a/build/create-local-env.ts
+++ b/build/create-local-env.ts
@@ -26,13 +26,15 @@ function processEnvironmentFiles(paths: string[]) {
       const resolvedNewFilePath = path.resolve(newFilePath);
 
       if (fs.existsSync(resolvedNewFilePath)) {
-        console.log(`  Skipping: '${newFilePath}' already exists`);
+        console.log(` ↳ SKIPPED: '${newFilePath}' already exists`);
       } else {
         fs.writeFileSync(resolvedNewFilePath, content, 'utf8');
-        console.log(`  Finished: Add correct env values to '${newFilePath}'`);
+        console.log(
+          ` ↳ FINISHED: Now add correct env values to '${newFilePath}'`
+        );
       }
     } else {
-      logError('  Skipping: Env file not found or invalid');
+      logError(' ↳ SKIPPED: Env file not found or invalid');
     }
 
     console.log('\n');

--- a/projects/ui/src/build/runBuild.ts
+++ b/projects/ui/src/build/runBuild.ts
@@ -2,6 +2,10 @@ import { buildThemeCss } from './styles/buildThemeCss';
 import { buildTypographyCss } from './styles/buildTypographyCss';
 import { buildIcons } from './svgs/buildIcons';
 
-buildThemeCss();
-buildTypographyCss();
-buildIcons();
+async function run() {
+  await buildThemeCss();
+  await buildTypographyCss();
+  buildIcons();
+}
+
+run();

--- a/projects/ui/src/build/styles/buildTypographyCss.ts
+++ b/projects/ui/src/build/styles/buildTypographyCss.ts
@@ -1,12 +1,14 @@
 import * as fs from 'fs-extra';
-import { Fonts, type Typography, typography } from '../../lib/styles';
-import {
-  anyModifiedSourceFiles,
-  fileCommentHeader,
-  formatCode,
-} from '../utils';
+import { type TypographySets, defaultThemeTypography } from '../../lib/styles';
+import { shouldGenerateFile, fileCommentHeader, formatCode } from '../utils';
 
-const OUT_FILE_PATH = './projects/ui/src/css/typography.css';
+const themes = [
+  {
+    srcFiles: ['./projects/ui/src/lib/styles/typography.ts'],
+    outFilePath: './projects/ui/src/css/typography.css',
+    typographySet: defaultThemeTypography,
+  },
+];
 
 const template = `
 {{SELECTOR}} {
@@ -20,20 +22,19 @@ const typeVar = (group: string, variant: string) =>
   `--type-${group}-${variant}`;
 
 const transformToVariables = async (
-  typography: Typography,
+  typography: TypographySets,
   selector: string
 ) => {
-  const fonts = Object.entries(Fonts)
-    .map(([fontName, fontValue]) => `${fontVar(fontName)}: ${fontValue};`)
+  const fonts = Object.entries(typography)
+    .map(([_, font]) => `${fontVar(font.id)}: ${font.family};`)
     .join('\n');
 
   const variables = Object.values(typography)
     .map((group) =>
       Object.entries(group.values)
         .map(
-          ([variantKey, variant]) =>
-            `${typeVar(group.id, variantKey)}:
-              ${variant.size}/${variant.lineHeight} ${`var(${fontVar(variant.font)})`};`
+          ([variantKey, variant]) => `${typeVar(group.id, variantKey)}:
+              ${variant.size}/${variant.lineHeight} var(${fontVar(group.id)});`
         )
         .join('\n')
     )
@@ -49,19 +50,27 @@ const transformToVariables = async (
 };
 
 export const buildTypographyCss = async () => {
-  const hasModifiedSourceFiles = anyModifiedSourceFiles(OUT_FILE_PATH, [
-    './projects/ui/src/lib/styles/typography.ts',
-  ]);
+  for (const theme of themes) {
+    console.log(`\nCreating "${theme.outFilePath}"`);
 
-  if (!hasModifiedSourceFiles) {
-    console.log('SKIPPING build:typography - no modified files');
-    return;
+    const hasModifiedSourceFiles = shouldGenerateFile(
+      theme.outFilePath,
+      theme.srcFiles
+    );
+
+    if (!hasModifiedSourceFiles) {
+      console.log(` ↳ SKIPPED - No modified source files`);
+      return;
+    }
+
+    fs.outputFileSync(theme.outFilePath, fileCommentHeader);
+
+    const typographyCss = await transformToVariables(
+      theme.typographySet,
+      ':root'
+    );
+    fs.appendFileSync(theme.outFilePath, typographyCss);
+
+    console.log(` ↳ FINISHED building typography file`);
   }
-
-  console.log(`Generating new typography file: ${OUT_FILE_PATH}`);
-
-  fs.outputFileSync(OUT_FILE_PATH, fileCommentHeader);
-
-  const typographyCss = await transformToVariables(typography, ':root');
-  fs.appendFileSync(OUT_FILE_PATH, typographyCss);
 };

--- a/projects/ui/src/build/svgs/buildIcons.ts
+++ b/projects/ui/src/build/svgs/buildIcons.ts
@@ -1,30 +1,32 @@
 import { readDirForSvg } from './readDirForSvg';
 import { optimizeSvgs } from './optimizeSvgs';
 import { createSvgStore } from './createSvgStore';
-import { anyModifiedSourceFiles } from '../utils';
+import { shouldGenerateFile } from '../utils';
 
 export const buildIcons = () => {
   const SVG_SRC_DIRECTORY = './projects/ui/src/lib/icons/svgs';
   const SVG_STORE_FILE_PATH = './projects/ui/src/lib/icons/svgIconStore.ts';
 
+  console.log(`\nCreating "${SVG_STORE_FILE_PATH}"`);
+
   const svgs = readDirForSvg(SVG_SRC_DIRECTORY);
   const svgPaths = svgs.map((svg) => svg.path);
 
-  const hasModifiedSourceFiles = anyModifiedSourceFiles(
+  const hasModifiedSourceFiles = shouldGenerateFile(
     SVG_STORE_FILE_PATH,
     svgPaths
   );
 
   if (!hasModifiedSourceFiles) {
-    console.log('SKIPPING build:icons - no modified files');
+    console.log(` ↳ SKIPPED - No modified source files`);
     return;
   }
-
-  console.log(`Generating new icons file: ${SVG_STORE_FILE_PATH}`);
 
   const optimizedSvgFiles = optimizeSvgs(svgs, SVG_SRC_DIRECTORY, {
     removeFill: true,
   });
 
   createSvgStore(optimizedSvgFiles, SVG_STORE_FILE_PATH);
+
+  console.log(` ↳ FINISHED building icon store`);
 };

--- a/projects/ui/src/build/utils.ts
+++ b/projects/ui/src/build/utils.ts
@@ -3,12 +3,11 @@ import * as prettier from 'prettier';
 import { type BuiltInParserName } from 'prettier';
 
 /**
- * Check if any source files have been modified after the output file.
+ * Check whether a new file should be generated:
+ *  - if the output file does not exist
+ *  - if the modified date of any source file is after that of the output file
  */
-export const anyModifiedSourceFiles = (
-  outFilePath: string,
-  sources: string[]
-) => {
+export const shouldGenerateFile = (outFilePath: string, sources: string[]) => {
   const doesOutputFileExist = fs.existsSync(outFilePath);
   if (!doesOutputFileExist) {
     return true;
@@ -16,9 +15,11 @@ export const anyModifiedSourceFiles = (
 
   const outputFileModifiedDate = fs.statSync(outFilePath).mtime.toISOString();
 
-  return sources.some(
+  const anyRecentlyModified = sources.some(
     (path) => fs.statSync(path).mtime.toISOString() > outputFileModifiedDate
   );
+
+  return anyRecentlyModified;
 };
 
 /**

--- a/projects/ui/src/css/theme.css
+++ b/projects/ui/src/css/theme.css
@@ -1,5 +1,5 @@
 /**
- * Auto-generated on Fri Apr 11 2025. Do not modify.
+ * Auto-generated on Thu Jul 24 2025. Do not modify.
  */
 :root,
 .theme-light {

--- a/projects/ui/src/css/typography.css
+++ b/projects/ui/src/css/typography.css
@@ -1,9 +1,9 @@
 /**
- * Auto-generated on Fri Apr 11 2025. Do not modify.
+ * Auto-generated on Thu Jul 24 2025. Do not modify.
  */
 :root {
   --font-family-display: Inter, -apple-system, 'Helvetica Neue', sans-serif;
-  --font-family-body: Inter, -apple-system, 'Helvetica Neue', sans-serif;
+  --font-family-text: Inter, -apple-system, 'Helvetica Neue', sans-serif;
   --font-family-mono:
     source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 
@@ -14,9 +14,12 @@
   --type-display-sm: 30px/1.27 var(--font-family-display);
   --type-display-xs: 24px/1.33 var(--font-family-display);
 
-  --type-text-xl: 20px/1.5 var(--font-family-body);
-  --type-text-lg: 18px/1.56 var(--font-family-body);
-  --type-text-md: 16px/1.5 var(--font-family-body);
-  --type-text-sm: 14px/1.43 var(--font-family-body);
-  --type-text-xs: 12px/1.5 var(--font-family-body);
+  --type-text-xl: 20px/1.5 var(--font-family-text);
+  --type-text-lg: 18px/1.56 var(--font-family-text);
+  --type-text-md: 16px/1.5 var(--font-family-text);
+  --type-text-sm: 14px/1.43 var(--font-family-text);
+  --type-text-xs: 12px/1.5 var(--font-family-text);
+
+  --type-mono-md: 16px/1.5 var(--font-family-mono);
+  --type-mono-sm: 14px/1.43 var(--font-family-mono);
 }

--- a/projects/ui/src/lib/foundations/Typography.mdx
+++ b/projects/ui/src/lib/foundations/Typography.mdx
@@ -1,5 +1,5 @@
 import { Heading, Meta, Subheading } from '@storybook/addon-docs/blocks';
-import { typography } from '../styles';
+import { typographyDictionary, defaultThemeTypography } from '../styles';
 
 <Meta title="foundations/Typography" />
 
@@ -8,9 +8,17 @@ import { typography } from '../styles';
 Font is [Inter](https://fonts.google.com/specimen/Inter) and variables sourced from [Untitled UI](https://www.untitledui.com/components/typography-styles).
 
 <div>
-  {Object.values(typography).map((group) => (
+  {Object.values(defaultThemeTypography).map((group) => (
     <div key={group.id} style={{ marginBlock: 40 }}>
-      <Heading>{group.name}</Heading>
+      <Heading>{typographyDictionary[group.id].name}</Heading>
+
+      <p>
+        {typographyDictionary[group.id].description}
+      </p>
+      <p>
+        <code>font-family: {group.family}</code>
+      </p>
+
       <div class="list sb-unstyled theme-light">
         {Object.entries(group.values).map(([variantKey, variant]) => {
           const variable = `type-${group.id}-${variantKey}`
@@ -65,8 +73,8 @@ Use the CSS `font` property and combine the weight with the variable:
 
 ```css
 /* bold and large */
-font: 700 var(--text-display-lg);
+font: 700 var(--type-display-lg);
 
 /* regular and small */
-font: 400 var(--text-type-sm);
+font: 400 var(--type-text-sm);
 ```

--- a/projects/ui/src/lib/styles/typography.ts
+++ b/projects/ui/src/lib/styles/typography.ts
@@ -1,90 +1,85 @@
-export const Fonts = {
-  display: `Inter, -apple-system, 'Helvetica Neue', sans-serif`,
-  body: `Inter, -apple-system, 'Helvetica Neue', sans-serif`,
-  mono: `source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace`,
-} as const;
-export type Font = keyof typeof Fonts;
-
-export type TypographyVariant = {
+type TypographyVariant = {
   size: string;
   lineHeight: string;
-  font: Font;
 };
 
-export type TypographySet = {
-  name: string;
-  id: string;
-  values: Record<string, TypographyVariant>;
+type TypographySize =
+  | '3xl'
+  | '2xl'
+  | 'xl'
+  | 'lg'
+  | 'md'
+  | 'sm'
+  | 'xs'
+  | '2xs'
+  | '3xs';
+
+export type TypographySets = {
+  display: {
+    id: 'display';
+    family: string;
+    values: Partial<Record<TypographySize, TypographyVariant>>;
+  };
+  text: {
+    id: 'text';
+    family: string;
+    values: Partial<Record<TypographySize, TypographyVariant>>;
+  };
+  mono: {
+    id: 'mono';
+    family: string;
+    values: Partial<Record<TypographySize, TypographyVariant>>;
+  };
 };
 
-export type Typography = Record<string, TypographySet>;
-
-export const typography: Typography = {
+export const typographyDictionary = {
   display: {
     name: 'Display',
-    id: 'display',
-    values: {
-      '2xl': {
-        size: '72px',
-        lineHeight: '1.25',
-        font: 'display',
-      },
-      xl: {
-        size: '60px',
-        lineHeight: '1.2',
-        font: 'display',
-      },
-      lg: {
-        size: '48px',
-        lineHeight: '1.25',
-        font: 'display',
-      },
-      md: {
-        size: '36px',
-        lineHeight: '1.22',
-        font: 'display',
-      },
-      sm: {
-        size: '30px',
-        lineHeight: '1.27',
-        font: 'display',
-      },
-      xs: {
-        size: '24px',
-        lineHeight: '1.33',
-        font: 'display',
-      },
-    },
+    description:
+      'Use for headings, hero text, or any large attention-grabbing text.',
   },
   text: {
     name: 'Text',
-    id: 'text',
+    description:
+      'Use for paragraphs, descriptions, UI labels, and when readability is key.',
+  },
+  mono: {
+    name: 'Monospace',
+    description:
+      'Use for for code, structured data, or when visual alignment is important.',
+  },
+} satisfies Record<keyof TypographySets, { name: string; description: string }>;
+
+export const defaultThemeTypography: TypographySets = {
+  display: {
+    id: 'display',
+    family: `Inter, -apple-system, 'Helvetica Neue', sans-serif`,
     values: {
-      xl: {
-        size: '20px',
-        lineHeight: '1.5',
-        font: 'body',
-      },
-      lg: {
-        size: '18px',
-        lineHeight: '1.56',
-        font: 'body',
-      },
-      md: {
-        size: '16px',
-        lineHeight: '1.5',
-        font: 'body',
-      },
-      sm: {
-        size: '14px',
-        lineHeight: '1.43',
-        font: 'body',
-      },
-      xs: {
-        size: '12px',
-        lineHeight: '1.5',
-        font: 'body',
-      },
+      '2xl': { size: '72px', lineHeight: '1.25' },
+      xl: { size: '60px', lineHeight: '1.2' },
+      lg: { size: '48px', lineHeight: '1.25' },
+      md: { size: '36px', lineHeight: '1.22' },
+      sm: { size: '30px', lineHeight: '1.27' },
+      xs: { size: '24px', lineHeight: '1.33' },
+    },
+  },
+  text: {
+    id: 'text',
+    family: `Inter, -apple-system, 'Helvetica Neue', sans-serif`,
+    values: {
+      xl: { size: '20px', lineHeight: '1.5' },
+      lg: { size: '18px', lineHeight: '1.56' },
+      md: { size: '16px', lineHeight: '1.5' },
+      sm: { size: '14px', lineHeight: '1.43' },
+      xs: { size: '12px', lineHeight: '1.5' },
+    },
+  },
+  mono: {
+    id: 'mono',
+    family: `source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace`,
+    values: {
+      md: { size: '16px', lineHeight: '1.5' },
+      sm: { size: '14px', lineHeight: '1.43' },
     },
   },
 };


### PR DESCRIPTION
part 1 of refactoring CSS theme variables
- refactor the typography build script so it can be used for multiple themes
- add monoscript font variants
- update typography documentation in storybook